### PR TITLE
Fixed a crash in V8 by removing a @rules.unitammo reference

### DIFF
--- a/src/mi2u/ui/MapInfoDialog.java
+++ b/src/mi2u/ui/MapInfoDialog.java
@@ -100,8 +100,6 @@ public class MapInfoDialog extends BaseDialog{
                     tt.row();
                     addBoolString(() -> state.rules.onlyDepositCore, "@rules.onlydepositcore", tt);
                     tt.row();
-                    addBoolString(() -> state.rules.unitAmmo, "@rules.unitammo", tt);
-                    tt.row();
                     addBoolString(() -> state.rules.possessionAllowed, "@mapInfo.possessionAllowed", tt);
                     tt.row();
                     addBoolString(() -> state.rules.coreCapture, "@rules.corecapture", tt);


### PR DESCRIPTION
The "unitammo" rule was removed in V8 and the addBoolString reference to the, now removed, rule was causing a crash when trying to open the Map Info UI.

All I did was remove the addBoolString reference along side it's corresponding tt.row.

Also I don't know how to "build" Mindustry mods so I was unable to test this change in-game myself (but the change is in such a minor section of the program I doubt it'll cause any issues).